### PR TITLE
Add Soperator Object Storage checkpointing guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ To get started, first choose:
 | --- | --- |
 | Verify your GPU environment works | [`skypilot/examples/basic-job.yaml`](./skypilot/examples/basic-job.yaml) or [`volcano/nccl-test-pytorch/`](./volcano/nccl-test-pytorch/) |
 | Run a simple distributed training example | [`slurm/hf-accelerate/`](./slurm/hf-accelerate/) |
+| Persist and recover Slurm training checkpoints | [`slurm/object-storage-checkpointing/`](./slurm/object-storage-checkpointing/) |
 | Use a generic PyTorch DDP training template | [`slurm/train-script/`](./slurm/train-script/) |
 | Fine-tune an LLM on Slurm | [`slurm/torchtune/`](./slurm/torchtune/) |
 | Run RLHF / VERL training | [`slurm/verl/`](./slurm/verl/) |
@@ -77,7 +78,7 @@ Most recipes follow the same high-level flow:
 - [`pytorch-dsv3-mxfp8/`](./pytorch-dsv3-mxfp8/) - DeepSeek-V3 pre-training recipes for large B200 Slurm clusters
 - [`runai/`](./runai/) - Run:ai examples for distributed MPI / NCCL validation
 - [`skypilot/`](./skypilot/) - SkyPilot job examples for training, inference, storage, and migration
-- [`slurm/`](./slurm/) - Slurm / Soperator recipes for distributed training, fine-tuning, and RLHF
+- [`slurm/`](./slurm/) - Slurm / Soperator recipes for distributed training, durable checkpoint recovery, fine-tuning, and RLHF
 - [`volcano/`](./volcano/) - Volcano scheduler examples for Kubernetes batch workloads
 - [`workload-samples/`](./workload-samples/) - Supporting container build examples for selected workloads
 
@@ -142,6 +143,9 @@ Here’s a sneak peek of the recipes available in this cookbook:
 - **I need shared storage before training**
   - Use [`common/shared-filesystem-mount/`](./common/shared-filesystem-mount/)
   - Then use [`common/hf-downloader/`](./common/hf-downloader/)
+
+- **I need durable Object Storage checkpoints for Slurm training**
+  - Use [`slurm/object-storage-checkpointing/`](./slurm/object-storage-checkpointing/)
 
 ## License
 

--- a/slurm/object-storage-checkpointing/.gitignore
+++ b/slurm/object-storage-checkpointing/.gitignore
@@ -1,0 +1,6 @@
+.env/
+.setup.lock
+__pycache__/
+*.py[cod]
+bin/
+outputs/

--- a/slurm/object-storage-checkpointing/README.md
+++ b/slurm/object-storage-checkpointing/README.md
@@ -24,6 +24,101 @@ PyTorch Distributed Checkpoint (DCP) pattern: asynchronous sharded uploads, an
 atomic commit marker, retention, consistent failure handling across ranks, and
 signal-safe shutdown.
 
+## Interruptions, signals, and checkpoint recovery
+
+A signal is a short operating-system notification sent to a running process. It
+does not contain checkpoint data, and receiving one does not by itself mean that
+Slurm will restart the job. Signals only give the trainer a chance to react
+before its processes disappear.
+
+The signals relevant to this recipe are:
+
+- `SIGUSR1`: an application-defined warning. This recipe asks Slurm to send it
+  before the job time limit and interprets it as "finish the current safe step,
+  commit a checkpoint, and exit."
+- `SIGTERM`: a request to terminate cleanly. Slurm uses it when a job reaches
+  its time limit or is cancelled. The trainer handles it like `SIGUSR1`, but
+  there may be much less time available.
+- `SIGCONT`: a wake-up signal that Slurm sends before some warnings and
+  termination sequences. The trainer does not need a handler for it.
+- `SIGKILL`: an immediate, uncatchable stop. No handler, cleanup callback, or
+  final checkpoint can run after it.
+
+There are therefore two recovery paths:
+
+```text
+planned stop: SIGUSR1/SIGTERM -> safe step boundary -> final commit -> exit
+hard stop:    node loss/SIGKILL -> previous marker stays valid -> restart -> resume
+```
+
+### What can happen on Nebius Soperator
+
+| Event | What the training ranks can rely on | Recommended checkpoint behavior | Restart behavior |
+| --- | --- | --- | --- |
+| Job approaches its Slurm time limit | Because the job requests `--signal=USR1@120`, Slurm signals all job steps approximately 120 seconds before the limit. Slurm may send the warning up to 60 seconds earlier than requested. At the limit, remaining tasks receive `SIGCONT` and `SIGTERM`, followed later by `SIGKILL` if they do not exit. | Treat `SIGUSR1` or `SIGTERM` as a request to stop collectively at the next safe step, drain any upload, and commit the current step. Measure your worst-case step and save time before choosing the warning window. | A time limit is not automatically requeued by `--requeue` alone; site policy may differ. Resubmit with the same prefix if needed. |
+| A preemptible Nebius worker VM is stopped | Nebius Compute gives the VM a 60-second termination notice, but that is a VM-level lifecycle event, not a guaranteed Slurm signal to every training rank. In Soperator, assume no usable in-band warning unless your platform team has explicitly validated propagation to the ranks. | Depend on periodic committed checkpoints, not a final signal-triggered save. A partial upload cannot replace `latest`. | `--requeue` makes the job eligible to return to the queue when Slurm records the node failure. The job can resume only after the platform has restored enough worker capacity. |
+| Hardware, network, Kubernetes-node, or VM failure | Usually no warning. One rank may disappear while the others report NCCL/Gloo errors or stall until Slurm detects the failed node. | Use the same hard-stop path as preemption: retain the previous marker and resume from it. | Requeue depends on how Slurm classifies the failure and on site policy. Node repair or replacement remains a platform responsibility. |
+| [`scancel <job-id>`](https://slurm.schedmd.com/scancel.html) | Slurm sends `SIGCONT` and `SIGTERM`, waits the site `KillWait`, then sends `SIGKILL` if tasks remain. | The trainer attempts a final checkpoint, but cancellation is not a generous warning mechanism. For a deliberate graceful stop, prefer `scancel --signal=USR1 <job-id>` and wait for the committed-checkpoint log line. | `scancel` does not requeue the job. Resubmit with the old explicit prefix to continue. |
+| [`scontrol requeue <job-id>`](https://slurm.schedmd.com/scontrol.html#OPT_requeue) | Slurm ends the current allocation and returns the same job ID to the queue. Do not assume the termination window is long enough for a new checkpoint. | The final signal save is useful when it completes, but correctness still comes from the latest checkpoint committed before requeue. | Yes. The default prefix contains the unchanged job ID, so the restarted job resumes automatically. |
+
+[Nebius documents](https://docs.nebius.com/compute/virtual-machines/preemptible)
+a 60-second `SIGTERM` before a preemptible VM is stopped, and then a forced stop
+if it does not exit. That notice protects VM shutdown; it must not be confused
+with Slurm's delivery of a signal to every `srun` task. For distributed
+training, the safe assumption is that preemption and node loss are hard stops.
+
+Slurm's [`--signal=USR1@120`](https://slurm.schedmd.com/sbatch.html#OPT_signal)
+is different: it is an explicit scheduler warning requested by this job. The
+directive intentionally has no `B:` prefix, because `B:` would signal only the
+batch shell; without it, Slurm signals the job steps that contain the training
+ranks. Slurm documents its full
+[job-termination sequence](https://slurm.schedmd.com/job_launch.html#job_termination)
+separately.
+
+### How the trainer handles a catchable signal
+
+The signal handler only sets a flag. It does not call PyTorch, Object Storage,
+or a distributed collective while the signal is executing asynchronously.
+Then, at each training-step boundary:
+
+1. all ranks combine their stop flags on a dedicated control process group
+2. all ranks leave the training loop together
+3. any in-flight asynchronous checkpoint is allowed to finish
+4. if that checkpoint does not already cover the current step, all ranks write
+   one synchronous final checkpoint
+5. rank zero advances `latest` only after the checkpoint is complete
+
+This collective decision is essential. If only the rank that received the
+signal exits, its peers can deadlock in the next training or checkpoint
+collective.
+
+### What to do after an interruption
+
+First inspect the end of the job log. If it contains both
+`stop signal observed at a safe step boundary` and `checkpoint committed`, the
+graceful path completed. If those lines are absent, assume a hard stop and use
+the previous committed marker.
+
+Check Slurm's view of the event and restart count:
+
+```bash
+sacct -j <job-id> -X \
+  --format=JobID,State,ExitCode,Restarts,Elapsed,NodeList
+```
+
+- If the same job returns to `PENDING` or `RUNNING`, `--requeue` is handling the
+  restart and the default prefix will resume automatically.
+- If the job is terminal, such as `CANCELLED` or `TIMEOUT`, submit a new job with
+  the prior prefix:
+
+  ```bash
+  TRAIN_ARGS="--prefix checkpointing-demo-<old-job-id>" sbatch checkpoint_train.sh
+  ```
+
+The practical rule is simple: use periodic checkpoints for failures that give
+no warning, and use signals only to reduce lost work when Slurm offers a planned
+shutdown window.
+
 ## Prerequisites
 
 Before you start, make sure you have:
@@ -258,24 +353,6 @@ TRAIN_ARGS="--prefix checkpointing-demo-123" sbatch checkpoint_train.sh
 
 DCP can reshard a checkpoint when the new job uses a different rank count.
 The model and optimizer definitions must remain checkpoint-compatible.
-
-### Interruption behavior
-
-The signal handler records intent only. At each safe step boundary, ranks
-collectively decide whether to stop, drain any in-flight upload, and commit the
-current step. Performing checkpoint work directly inside a signal handler or
-letting one rank leave independently can deadlock distributed training.
-
-| Event | Rank behavior | Automatic resume |
-| --- | --- | --- |
-| Node loss or preemption | No usable warning should be assumed | Slurm can requeue the job; node recovery remains an operator responsibility |
-| Time limit | `SIGUSR1` warning, followed by `SIGTERM` at the limit | Depends on site policy |
-| `scancel <job-id>` | `SIGTERM`, then eventual `SIGKILL` | No |
-| `scancel --signal=USR1 <job-id>` | Graceful checkpoint and exit | No; resubmit with the same prefix |
-| `scontrol requeue <job-id>` | Terminates the allocation and returns the same job ID to the queue | Yes |
-
-The `--signal` directive intentionally has no `B:` prefix. That prefix would
-signal only the batch shell instead of the training ranks.
 
 ## Apply the protocol to another workload
 

--- a/slurm/object-storage-checkpointing/README.md
+++ b/slurm/object-storage-checkpointing/README.md
@@ -94,10 +94,11 @@ collective.
 
 ### What to do after an interruption
 
-First inspect the end of the job log. If it contains both
-`stop signal observed at a safe step boundary` and `checkpoint committed`, the
-graceful path completed. If those lines are absent, assume a hard stop and use
-the previous committed marker.
+First inspect the end of the job log. If it contains
+`SIGUSR1 observed at a safe step boundary` or
+`SIGTERM observed at a safe step boundary`, followed by `checkpoint committed`,
+the graceful path completed. If those lines are absent, assume a hard stop and
+use the previous committed marker.
 
 Check Slurm's view of the event and restart count:
 
@@ -126,8 +127,8 @@ Before you start, make sure you have:
 - access to a [Nebius Soperator cluster](https://nebius.com/services/soperator)
   with two GPU worker nodes
 - this repository cloned to the shared filesystem
-- Linux and Python 3.10 or newer with `venv`, `curl`, `tar`, and `sha256sum`
-  on the login node
+- Linux and Python 3.10 or newer with `venv`, `curl`, `tar`, `sha256sum`, and
+  `flock` on the login node
 - a readable `/etc/nebius-checkpoints.env` prepared by the platform operator
 
 Check the platform handoff without displaying any credentials:
@@ -162,8 +163,8 @@ bash setup.sh
 
 The setup script:
 
-1. creates a shared `.env` virtual environment
-2. installs the exact versions from `requirements.txt`
+1. takes an exclusive setup lock and creates a shared `.env` virtual environment
+2. installs the pinned pip version and exact versions from `requirements.txt`
 3. downloads checksum-verified `s5cmd` 2.3.0 into `bin/`
 4. creates `outputs/` for Slurm logs
 5. verifies create, read, and delete access to the checkpoint bucket

--- a/slurm/object-storage-checkpointing/README.md
+++ b/slurm/object-storage-checkpointing/README.md
@@ -127,7 +127,7 @@ Before you start, make sure you have:
 - access to a [Nebius Soperator cluster](https://nebius.com/services/soperator)
   with two GPU worker nodes
 - this repository cloned to the shared filesystem
-- Linux and Python 3.10 or newer with `venv`, `curl`, `tar`, `sha256sum`, and
+- Linux and Python 3.11 or newer with `venv`, `curl`, `tar`, `sha256sum`, and
   `flock` on the login node
 - a readable `/etc/nebius-checkpoints.env` prepared by the platform operator
 

--- a/slurm/object-storage-checkpointing/README.md
+++ b/slurm/object-storage-checkpointing/README.md
@@ -131,6 +131,10 @@ Before you start, make sure you have:
   `flock` on the login node
 - a readable `/etc/nebius-checkpoints.env` prepared by the platform operator
 
+Standard Soperator 4.1.x jail images include these command-line tools. The setup
+script checks them explicitly so that older or customized images fail with a
+clear request for the platform operator.
+
 Check the platform handoff without displaying any credentials:
 
 ```bash
@@ -141,13 +145,13 @@ else
 fi
 ```
 
-If the file is missing, send the operator this request:
+If the file is missing or unreadable, send the operator this request:
 
 > Enable Soperator Object Storage checkpointing for this cluster and make
 > `/etc/nebius-checkpoints.env` readable by my Slurm user.
 
-The researcher does not need to create a bucket, access key, or IAM policy.
-Those platform details are collected in
+You do not need to create a bucket, access key, or IAM policy. Those platform
+details are collected in
 [For platform operators](#for-platform-operators).
 
 ## Steps
@@ -195,7 +199,7 @@ Useful trainer options include:
 | --- | ---: | --- |
 | `--save-every-seconds` | `120` | Time-based checkpoint cadence |
 | `--save-every-steps` | unset | Step-based cadence; overrides time-based cadence |
-| `--keep-last` | `3` | Number of committed checkpoints to retain; `0` keeps all |
+| `--keep-last` | `3` | Number of committed checkpoints to retain; `0` keeps all committed checkpoints, while stale uncommitted steps are still removed |
 | `--prefix` | job name and job ID | Object key namespace used for resume |
 | `--steps` | `10000000` | Maximum training steps |
 
@@ -315,9 +319,9 @@ GPU-to-host staging, while Object Storage transfer continues in a background
 thread.
 
 Only one save is allowed in flight. Before another save begins, all ranks confirm
-that the previous upload and commit succeeded. A persistence failure on one rank
-is converted into a fatal error on every rank instead of leaving peers stuck in
-a later collective.
+that the previous upload and marker commit succeeded. A checkpoint upload or
+marker failure on one rank is converted into a fatal error on every rank instead
+of leaving peers stuck in a later collective.
 
 ### Atomic commit marker
 
@@ -334,7 +338,10 @@ or throttling, the job fails instead of silently starting from step zero.
 
 A hard kill during upload can leave objects or multipart uploads under a newer
 step, but `latest` continues to identify the previous complete checkpoint.
-Retention removes these stale step directories after the next successful commit.
+Cleanup removes these stale step directories after the next successful commit,
+including when `--keep-last=0`. Retention runs only after `latest` is committed;
+if cleanup fails, the committed checkpoint remains valid, the job logs a warning,
+and cleanup is retried after the next commit.
 
 ### Prefixes and resume behavior
 
@@ -365,7 +372,8 @@ these invariants:
 - publish the marker only after every checkpoint object is complete
 - resume only from the marker
 - treat marker read errors as fatal
-- make persistence failures fatal on all ranks
+- make checkpoint upload and marker failures fatal on all ranks
+- treat retention cleanup as retryable housekeeping after a successful commit
 - coordinate stop decisions at safe collective boundaries
 - keep a prefix single-writer
 - measure staging and upload time before choosing a cadence
@@ -380,7 +388,8 @@ marker only after the upload succeeds.
   FP32 weights plus two FP32 AdamW moments are roughly 12 bytes per parameter.
 - Bucket capacity should cover `keep_last × checkpoint size` plus any separately
   retained milestone checkpoints.
-- The log reports both training-blocking staging time and total upload time.
+- The log reports both training-blocking staging time and total upload time, and
+  reports the complete duration of a final synchronous save through marker commit.
 - A starting interval can use the Young/Daly approximation
   `sqrt(2 × checkpoint blocking time × mean time between failures)`.
 - The background upload must finish before the next interval. Otherwise host
@@ -407,8 +416,9 @@ cross-cluster reuse belong to the linked Soperator infrastructure workflow.
 
 ## Troubleshooting
 
-- `/etc/nebius-checkpoints.env` is missing: confirm checkpoint storage is enabled
-  in the Soperator installation and that its credential-rendering job completed.
+- `/etc/nebius-checkpoints.env` is missing or unreadable: confirm checkpoint
+  storage is enabled in the Soperator installation, its credential-rendering job
+  completed, and the Slurm user has read access.
 - Setup reports an Object Storage permission error: verify the service account has
   create, read, and delete access on the configured bucket.
 - The job refuses to start fresh after a marker error: this is intentional. Fix

--- a/slurm/object-storage-checkpointing/README.md
+++ b/slurm/object-storage-checkpointing/README.md
@@ -1,0 +1,391 @@
+# Running PyTorch training with persistent Object Storage checkpoints on Slurm (Soperator)
+
+Use this recipe when training checkpoints are filling the shared Soperator jail,
+or when a job interruption would otherwise lose hours of progress. Every rank
+writes its checkpoint shard directly to Nebius Object Storage: checkpoint data
+does not stage in, or consume capacity from, the jail.
+
+After an interruption, the job reads one small `latest` marker and resumes from
+the newest complete checkpoint. A hard kill during an upload cannot replace that
+marker with an incomplete checkpoint.
+
+## What this gives you
+
+| Situation | Result |
+| --- | --- |
+| Checkpoints are too large for the shared jail | Shards are uploaded directly to Object Storage; no checkpoint directory is created in the jail |
+| Slurm requeues the job after a node interruption | The same job ID resumes automatically from its latest complete checkpoint |
+| You stop and resubmit a job | Pass the old prefix and resume from the same checkpoint |
+| A rank is killed during an upload | The previous committed checkpoint remains safe and resumable |
+| A cluster is replaced | An operator can attach the old bucket and the researcher can reuse the prefix |
+
+The included model is intentionally small. The reusable part is the FSDP2 and
+PyTorch Distributed Checkpoint (DCP) pattern: asynchronous sharded uploads, an
+atomic commit marker, retention, consistent failure handling across ranks, and
+signal-safe shutdown.
+
+## Prerequisites
+
+Before you start, make sure you have:
+
+- access to a [Nebius Soperator cluster](https://nebius.com/services/soperator)
+  with two GPU worker nodes
+- this repository cloned to the shared filesystem
+- Linux and Python 3.10 or newer with `venv`, `curl`, `tar`, and `sha256sum`
+  on the login node
+- a readable `/etc/nebius-checkpoints.env` prepared by the platform operator
+
+Check the platform handoff without displaying any credentials:
+
+```bash
+if test -r /etc/nebius-checkpoints.env; then
+  echo "Object Storage checkpointing is ready"
+else
+  echo "Ask the platform operator to enable Object Storage checkpointing"
+fi
+```
+
+If the file is missing, send the operator this request:
+
+> Enable Soperator Object Storage checkpointing for this cluster and make
+> `/etc/nebius-checkpoints.env` readable by my Slurm user.
+
+The researcher does not need to create a bucket, access key, or IAM policy.
+Those platform details are collected in
+[For platform operators](#for-platform-operators).
+
+## Steps
+
+### Set up the environment
+
+From the shared filesystem on the login node:
+
+```bash
+cd ml-cookbook/slurm/object-storage-checkpointing
+bash setup.sh
+```
+
+The setup script:
+
+1. creates a shared `.env` virtual environment
+2. installs the exact versions from `requirements.txt`
+3. downloads checksum-verified `s5cmd` 2.3.0 into `bin/`
+4. creates `outputs/` for Slurm logs
+5. verifies create, read, and delete access to the checkpoint bucket
+
+A successful setup ends with output similar to:
+
+```text
+Nebius Object Storage access OK: bucket=<bucket> endpoint=<endpoint>
+torch 2.13.0 / s3torchconnector DCP import OK
+Setup done.
+```
+
+### Examine and configure the job
+
+`checkpoint_train.sh` requests two nodes with eight GPUs per node, runs one task
+per GPU, and has a 30-minute time limit. It also enables:
+
+- `--requeue` for scheduler-driven node failure or preemption recovery
+- `--open-mode=append` so logs survive a requeue
+- `--signal=USR1@120` so ranks can commit a final checkpoint before a time limit
+
+Trainer arguments can be passed through `TRAIN_ARGS`. Slurm resource settings can
+be overridden on the `sbatch` command line.
+
+Useful trainer options include:
+
+| Option | Default | Purpose |
+| --- | ---: | --- |
+| `--save-every-seconds` | `120` | Time-based checkpoint cadence |
+| `--save-every-steps` | unset | Step-based cadence; overrides time-based cadence |
+| `--keep-last` | `3` | Number of committed checkpoints to retain; `0` keeps all |
+| `--prefix` | job name and job ID | Object key namespace used for resume |
+| `--steps` | `10000000` | Maximum training steps |
+
+Run `.env/bin/python train_fsdp.py --help` for the full argument list.
+
+### Submit the job
+
+For a small cross-node demonstration, use one GPU on each of two nodes and
+checkpoint every 60 seconds:
+
+```bash
+TRAIN_ARGS="--save-every-seconds 60 --keep-last 2" \
+  sbatch --gpus-per-node=1 --ntasks-per-node=1 checkpoint_train.sh
+```
+
+For the default two-node, eight-GPU-per-node allocation, run:
+
+```bash
+sbatch checkpoint_train.sh
+```
+
+The default prefix is `<job-name>-<job-id>`. It isolates independent submissions
+while remaining unchanged when Slurm requeues the same job.
+
+### Monitor the job
+
+Check the queue:
+
+```bash
+squeue --me
+```
+
+Follow the combined stdout/stderr log:
+
+```bash
+tail -f outputs/checkpointing-demo-<job-id>.out
+```
+
+Inspect checkpoint objects:
+
+```bash
+source /etc/nebius-checkpoints.env
+bin/s5cmd --endpoint-url "$NEBIUS_OBJECT_STORAGE_ENDPOINT" \
+  ls "s3://$NEBIUS_CHECKPOINT_BUCKET/*"
+```
+
+### Expected output
+
+Exact steps and timings depend on the GPU type and Object Storage throughput.
+A healthy run shows the initial state, asynchronous staging time, upload
+completion, and marker commit:
+
+```text
+[12:00:00] world=16 params=...M (FSDP2-sharded) checkpoint~...GB bucket=... prefix=checkpointing-demo-123
+[12:00:00] no checkpoint found, starting fresh
+[12:02:01] step 42 loss ...: async_save blocked training for ...ms
+[12:02:05] checkpoint step 42: upload finished in ...s, marker committed
+```
+
+On a requeue or explicit-prefix resubmission, it instead reports:
+
+```text
+resuming from checkpoint step 42
+```
+
+### Try an interruption and resume
+
+Wait until the log says `marker committed`, then requeue the job:
+
+```bash
+scontrol requeue <job-id>
+```
+
+The job keeps the same ID and prefix. Slurm allocates nodes again, the log is
+appended instead of truncated, and the restarted ranks print:
+
+```text
+resuming from checkpoint step <step>
+```
+
+There is still no model-checkpoint directory in the jail. The committed shards
+are under
+`s3://<bucket>/checkpointing-demo-<job-id>/step-<step>/` in Object Storage.
+
+## Verify checkpoint recovery
+
+After setup, run the automated verifier from the login node:
+
+```bash
+bash verify.sh
+```
+
+The verifier submits the real job with one GPU on each of two nodes and checks:
+
+1. a complete checkpoint is committed
+2. a hard `SIGKILL` cannot advance `latest` to an incomplete upload
+3. a new submission with the same prefix resumes and commits more progress
+4. `SIGUSR1` causes a final checkpoint before exit
+
+Each phase prints `PASS` or `FAIL`. The script exits non-zero on failure and
+cleans its unique `verify-*` prefix, including incomplete multipart uploads.
+Typical runtime is 5–10 minutes after both nodes are allocated; queue time is
+additional. Override queue and phase deadlines with `VERIFY_START_DEADLINE`,
+`VERIFY_COMMIT_DEADLINE`, and `VERIFY_RESUME_DEADLINE` if needed.
+
+Automatic Slurm requeue, real VM preemption, node replacement, and cross-cluster
+recovery remain manual tests because they depend on cluster policy and operator
+actions.
+
+## How checkpointing works
+
+### Sharded asynchronous saves
+
+The model is wrapped with FSDP2 `fully_shard`. DCP therefore gives every rank only
+its model and optimizer shard to upload. `dcp.async_save` blocks training for
+GPU-to-host staging, while Object Storage transfer continues in a background
+thread.
+
+Only one save is allowed in flight. Before another save begins, all ranks confirm
+that the previous upload and commit succeeded. A persistence failure on one rank
+is converted into a fatal error on every rank instead of leaving peers stuck in
+a later collective.
+
+### Atomic commit marker
+
+Nebius Object Storage does not provide an atomic directory rename. The recipe
+uses this protocol instead:
+
+1. write a new checkpoint below `<prefix>/step-<step>/`
+2. wait for DCP to finish every shard and the `.metadata` object
+3. overwrite the small `<prefix>/latest` object with the committed step
+
+Resume reads only `latest`. It never guesses the newest checkpoint by listing
+step directories. If marker access fails because of authentication, networking,
+or throttling, the job fails instead of silently starting from step zero.
+
+A hard kill during upload can leave objects or multipart uploads under a newer
+step, but `latest` continues to identify the previous complete checkpoint.
+Retention removes these stale step directories after the next successful commit.
+
+### Prefixes and resume behavior
+
+A prefix is a single-writer namespace. Never run two active jobs with the same
+explicit prefix because both would update `latest` and apply retention.
+
+- Slurm requeue: the default prefix is stable because the job ID is unchanged.
+- Separate submission: pass the earlier prefix explicitly.
+- Replacement cluster: reuse the bucket through the Soperator infrastructure,
+  then pass the earlier prefix explicitly.
+
+For example:
+
+```bash
+TRAIN_ARGS="--prefix checkpointing-demo-123" sbatch checkpoint_train.sh
+```
+
+DCP can reshard a checkpoint when the new job uses a different rank count.
+The model and optimizer definitions must remain checkpoint-compatible.
+
+### Interruption behavior
+
+The signal handler records intent only. At each safe step boundary, ranks
+collectively decide whether to stop, drain any in-flight upload, and commit the
+current step. Performing checkpoint work directly inside a signal handler or
+letting one rank leave independently can deadlock distributed training.
+
+| Event | Rank behavior | Automatic resume |
+| --- | --- | --- |
+| Node loss or preemption | No usable warning should be assumed | Slurm can requeue the job; node recovery remains an operator responsibility |
+| Time limit | `SIGUSR1` warning, followed by `SIGTERM` at the limit | Depends on site policy |
+| `scancel <job-id>` | `SIGTERM`, then eventual `SIGKILL` | No |
+| `scancel --signal=USR1 <job-id>` | Graceful checkpoint and exit | No; resubmit with the same prefix |
+| `scontrol requeue <job-id>` | Terminates the allocation and returns the same job ID to the queue | Yes |
+
+The `--signal` directive intentionally has no `B:` prefix. That prefix would
+signal only the batch shell instead of the training ranks.
+
+## Apply the protocol to another workload
+
+A production trainer does not need to copy the toy model, but it should preserve
+these invariants:
+
+- shard checkpoint state rather than gathering it on rank zero
+- serialize saves or otherwise prevent overlapping commits
+- publish the marker only after every checkpoint object is complete
+- resume only from the marker
+- treat marker read errors as fatal
+- make persistence failures fatal on all ranks
+- coordinate stop decisions at safe collective boundaries
+- keep a prefix single-writer
+- measure staging and upload time before choosing a cadence
+
+Frameworks without direct Object Storage support can save a completed checkpoint
+to local or shared storage, upload that completed directory, and advance the
+marker only after the upload succeeds.
+
+## Sizing and cadence
+
+- Checkpoint size is approximately bytes per parameter times parameter count.
+  FP32 weights plus two FP32 AdamW moments are roughly 12 bytes per parameter.
+- Bucket capacity should cover `keep_last × checkpoint size` plus any separately
+  retained milestone checkpoints.
+- The log reports both training-blocking staging time and total upload time.
+- A starting interval can use the Young/Daly approximation
+  `sqrt(2 × checkpoint blocking time × mean time between failures)`.
+- The background upload must finish before the next interval. Otherwise host
+  memory and pending-upload wait time can erase the benefit of asynchronous saves.
+- The Slurm warning window must cover the worst-case training step, any in-flight
+  upload drain, and the final synchronous save.
+
+## Cleanup
+
+`verify.sh` cleans only its own unique prefix. To remove a demo prefix manually,
+first confirm the exact prefix and then run:
+
+```bash
+source /etc/nebius-checkpoints.env
+PREFIX="checkpointing-demo-<job-id>"
+bin/s5cmd --endpoint-url "$NEBIUS_OBJECT_STORAGE_ENDPOINT" \
+  rm "s3://$NEBIUS_CHECKPOINT_BUCKET/$PREFIX/*"
+```
+
+This removes objects under that prefix; it does not delete the bucket. Interrupted
+uploads may also leave incomplete multipart uploads, which require an
+S3-compatible multipart-abort operation. Bucket retention, destruction, and
+cross-cluster reuse belong to the linked Soperator infrastructure workflow.
+
+## Troubleshooting
+
+- `/etc/nebius-checkpoints.env` is missing: confirm checkpoint storage is enabled
+  in the Soperator installation and that its credential-rendering job completed.
+- Setup reports an Object Storage permission error: verify the service account has
+  create, read, and delete access on the configured bucket.
+- The job refuses to start fresh after a marker error: this is intentional. Fix
+  credentials, endpoint, DNS, or transport access and resubmit with the same prefix.
+- A job hangs after only one rank receives a signal: make sure the workload keeps
+  the dedicated control process group and collective stop decision.
+- Resume finds incompatible state: use the same model and optimizer definitions,
+  or start a new prefix after an intentional incompatible change.
+- Output files cannot be opened: run `bash setup.sh` first so `outputs/` exists
+  before Slurm opens the log file.
+
+## For platform operators
+
+Researchers can skip this section once the readiness check passes.
+
+The platform-side reference is
+[nebius-solutions-library PR #1074](https://github.com/nebius/nebius-solutions-library/pull/1074),
+with an
+[immutable implementation commit](https://github.com/nebius/nebius-solutions-library/commit/56d3a164c31956cc134dbfd98f720d2e5dcc220f).
+Enable `checkpoint_storage_enabled = true` in the Soperator installation. The
+platform workflow provisions or attaches a bucket, creates least-privilege
+workload access, and renders `/etc/nebius-checkpoints.env` into the jail.
+
+The environment file must provide:
+
+| Variable | Purpose |
+| --- | --- |
+| `NEBIUS_CHECKPOINT_BUCKET` | Object Storage bucket name |
+| `NEBIUS_OBJECT_STORAGE_ENDPOINT` | Regional Object Storage endpoint |
+| `NEBIUS_OBJECT_STORAGE_REGION` | Signing region |
+| `AWS_ACCESS_KEY_ID` | S3-compatible SDK credential |
+| `AWS_SECRET_ACCESS_KEY` | S3-compatible SDK credential |
+
+The trainer maps `NEBIUS_OBJECT_STORAGE_ENDPOINT` to the `AWS_ENDPOINT_URL`
+compatibility variable before constructing the DCP reader or writer. The
+reference infrastructure also exports `AWS_ENDPOINT_URL` and `AWS_REGION` for
+other S3-compatible tools. The target remains Nebius Object Storage. Do not log
+the file. The infrastructure defaults to owner `root:root` and mode `600`;
+configure a numeric user/group and suitable mode when researchers submit as
+non-root users.
+
+Bucket retention, safe installation teardown, and attaching the bucket to a
+replacement cluster remain platform responsibilities. Existing buckets can be
+reused so researchers only need the old checkpoint prefix to resume.
+
+## Version notes
+
+The versions in `requirements.txt` were validated together on Soperator 4.1.3 and
+4.1.4 H100 clusters in the reference implementation.
+
+`s3torchconnector[dcp]`, `S3StorageReader`, `S3StorageWriter`,
+`S3ClientConfig`, `boto3`, `s5cmd`, `AWS_*`, and `s3://` retain their upstream
+S3-compatible API names. They are configured with the Nebius Object Storage
+endpoint, region, bucket, and credentials.
+
+`dcp.async_save` needs a CPU process-group backend alongside NCCL. The trainer
+initializes the default group with `cpu:gloo,cuda:nccl` and uses a separate Gloo
+group for main-thread control collectives.

--- a/slurm/object-storage-checkpointing/checkpoint_retention.py
+++ b/slurm/object-storage-checkpointing/checkpoint_retention.py
@@ -1,0 +1,22 @@
+"""Retention policy for committed and incomplete checkpoint steps."""
+
+from collections.abc import Iterable
+
+
+def plan_checkpoint_pruning(
+    steps: Iterable[int], committed_step: int, keep_last: int
+) -> list[tuple[int, str]]:
+    """Select stale partials and committed steps that should be deleted."""
+    if keep_last < 0:
+        raise ValueError("keep_last must be non-negative")
+
+    stale_partials = sorted(step for step in steps if step > committed_step)
+    doomed = [(step, "stale partial") for step in stale_partials]
+
+    # keep_last=0 means keep every committed checkpoint, but uncommitted steps
+    # above the marker remain garbage and are still selected above.
+    if keep_last > 0:
+        committed = sorted(step for step in steps if step <= committed_step)
+        doomed.extend((step, "retention") for step in committed[:-keep_last])
+
+    return doomed

--- a/slurm/object-storage-checkpointing/checkpoint_train.sh
+++ b/slurm/object-storage-checkpointing/checkpoint_train.sh
@@ -29,9 +29,14 @@ export PATH="${CHECKPOINTING_DIR}/bin:${PATH}"
 # Nebius Object Storage credentials, endpoint, and bucket, delivered by the
 # platform setup. AWS_* exports inside the file are SDK compatibility inputs;
 # workload-facing settings use NEBIUS_* names.
+ENV_FILE='/etc/nebius-checkpoints.env'
+if [ ! -r "${ENV_FILE}" ]; then
+  echo "ERROR: ${ENV_FILE} is missing or unreadable; see the README's platform-operators section." >&2
+  exit 1
+fi
 set -a
-# shellcheck disable=SC1091 # rendered by the platform checkpointing setup
-source /etc/nebius-checkpoints.env
+# shellcheck disable=SC1090 # rendered at an installation-specific path
+source "${ENV_FILE}"
 set +a
 
 MASTER_ADDR=$(scontrol show hostnames "$SLURM_JOB_NODELIST" | sed -n '1p')

--- a/slurm/object-storage-checkpointing/checkpoint_train.sh
+++ b/slurm/object-storage-checkpointing/checkpoint_train.sh
@@ -1,0 +1,62 @@
+#!/bin/bash
+
+#SBATCH --job-name=checkpointing-demo
+#SBATCH --output=outputs/%x-%j.out
+#SBATCH --error=outputs/%x-%j.out
+#SBATCH --nodes=2
+#SBATCH --gpus-per-node=8
+#SBATCH --ntasks-per-node=8
+#SBATCH --cpus-per-task=14
+# Bound the example allocation; override with sbatch --time for a longer run.
+#SBATCH --time=00:30:00
+# Requeue on node failure/preemption; the job auto-resumes from the latest
+# complete checkpoint in Object Storage (see train_fsdp.py).
+#SBATCH --requeue
+# Append to the log on requeue instead of truncating it.
+#SBATCH --open-mode=append
+# Ask Slurm to signal the job steps (the training ranks trap USR1) 120s before
+# a scheduled kill so they can commit the current step before exit. No "B:"
+# prefix: that would signal only the batch shell, never reaching the ranks.
+#SBATCH --signal=USR1@120
+
+set -euo pipefail
+
+# Slurm copies batch scripts to its spool dir, so resolve paths from the
+# submission directory (submit this job from the checkpointing directory).
+CHECKPOINTING_DIR="${SLURM_SUBMIT_DIR:-$(pwd)}"
+export PATH="${CHECKPOINTING_DIR}/bin:${PATH}"
+
+# Nebius Object Storage credentials, endpoint, and bucket, delivered by the
+# platform setup. AWS_* exports inside the file are SDK compatibility inputs;
+# workload-facing settings use NEBIUS_* names.
+set -a
+# shellcheck disable=SC1091 # rendered by the platform checkpointing setup
+source /etc/nebius-checkpoints.env
+set +a
+
+MASTER_ADDR=$(scontrol show hostnames "$SLURM_JOB_NODELIST" | sed -n '1p')
+[ -n "${MASTER_ADDR}" ] || { echo "ERROR: could not resolve the Slurm master node" >&2; exit 1; }
+export MASTER_ADDR
+if [ -z "${MASTER_PORT:-}" ]; then
+  # The batch shell runs on the first allocated node. Let its kernel choose a
+  # currently free port instead of mapping job IDs into a collision-prone range.
+  MASTER_PORT=$("${CHECKPOINTING_DIR}/.env/bin/python" - <<'PYEOF'
+import socket
+
+with socket.socket() as sock:
+    sock.bind(("", 0))
+    print(sock.getsockname()[1])
+PYEOF
+  )
+fi
+export MASTER_PORT
+
+# One task per GPU; torch reads its distributed config from these variables.
+srun --kill-on-bad-exit=1 bash -c "
+  export RANK=\$SLURM_PROCID
+  export WORLD_SIZE=\$SLURM_NTASKS
+  export LOCAL_RANK=\$SLURM_LOCALID
+  exec '${CHECKPOINTING_DIR}/.env/bin/python' '${CHECKPOINTING_DIR}/train_fsdp.py' \
+    --save-every-seconds 120 \
+    ${TRAIN_ARGS:-}
+"

--- a/slurm/object-storage-checkpointing/requirements.txt
+++ b/slurm/object-storage-checkpointing/requirements.txt
@@ -1,5 +1,4 @@
 # Versions validated together on Soperator 4.1.3 and 4.1.4 H100 reference clusters.
 torch==2.13.0
-numpy==2.5.1
 s3torchconnector[dcp]==1.5.0
 boto3==1.43.45

--- a/slurm/object-storage-checkpointing/requirements.txt
+++ b/slurm/object-storage-checkpointing/requirements.txt
@@ -1,4 +1,5 @@
 # Versions validated together on Soperator 4.1.3 and 4.1.4 H100 reference clusters.
 torch==2.13.0
+numpy==2.4.1
 s3torchconnector[dcp]==1.5.0
 boto3==1.43.45

--- a/slurm/object-storage-checkpointing/requirements.txt
+++ b/slurm/object-storage-checkpointing/requirements.txt
@@ -1,0 +1,5 @@
+# Versions validated together on Soperator 4.1.3 and 4.1.4 H100 reference clusters.
+torch==2.13.0
+numpy==2.5.1
+s3torchconnector[dcp]==1.5.0
+boto3==1.43.45

--- a/slurm/object-storage-checkpointing/setup.sh
+++ b/slurm/object-storage-checkpointing/setup.sh
@@ -1,0 +1,131 @@
+#!/bin/bash
+# Prepares the shared environment for the checkpointing examples.
+# Run once from a login node; the venv lands in the jail, so all nodes see it.
+set -euo pipefail
+
+CHECKPOINTING_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+VENV_DIR="${CHECKPOINTING_DIR}/.env"
+ENV_FILE='/etc/nebius-checkpoints.env'
+BIN_DIR="${CHECKPOINTING_DIR}/bin"
+
+require_command() {
+  if ! command -v "$1" >/dev/null; then
+    echo "ERROR: required command '$1' is not installed. $2" >&2
+    exit 1
+  fi
+}
+
+require_command python3 "Install Python 3 with the venv module on the login node."
+require_command curl "Install curl on the login node."
+require_command tar "Install tar on the login node."
+require_command sha256sum "Install GNU coreutils on the login node."
+if ! python3 -c 'import sys; raise SystemExit(sys.version_info < (3, 10))'; then
+  echo "ERROR: Python 3.10 or newer is required on the login node." >&2
+  exit 1
+fi
+
+# Slurm opens output files before the batch script starts, so create the shared
+# output directory during setup rather than requiring a manual extra step.
+mkdir -p "${CHECKPOINTING_DIR}/outputs" "${BIN_DIR}"
+
+if [ ! -f "${ENV_FILE}" ]; then
+  echo "ERROR: ${ENV_FILE} not found." >&2
+  echo "It is created from the jail-checkpoints k8s secret (checkpoints_access module)." >&2
+  echo "Make sure checkpoint_storage_enabled = true in your Terraform installation." >&2
+  exit 1
+fi
+
+if [ ! -d "${VENV_DIR}" ]; then
+  echo "Creating venv at ${VENV_DIR}..."
+  if ! python3 -m venv "${VENV_DIR}"; then
+    echo "ERROR: Python could not create a virtual environment. Install the distribution's python3-venv package." >&2
+    exit 1
+  fi
+fi
+
+echo "Installing pinned dependencies (torch download is large, be patient)..."
+"${VENV_DIR}/bin/pip" install --quiet --upgrade pip
+"${VENV_DIR}/bin/pip" install --quiet --requirement "${CHECKPOINTING_DIR}/requirements.txt"
+
+S5CMD="${BIN_DIR}/s5cmd"
+if [ -x "${S5CMD}" ]; then
+  case "$("${S5CMD}" version 2>/dev/null || true)" in
+    v2.3.0-*) ;;
+    *)
+      echo "Replacing unexpected s5cmd version in ${S5CMD}..."
+      rm -f "${S5CMD}"
+      ;;
+  esac
+fi
+if [ ! -x "${S5CMD}" ]; then
+  echo "Installing pinned s5cmd into the shared checkpointing directory..."
+  case "$(uname -m)" in
+    x86_64 | amd64)
+      S5CMD_ARCH="64bit"
+      S5CMD_SHA256="de0fdbfa3aceae55e069ba81a0fc17b2026567637603734a387b2fca06c299b4"
+      ;;
+    aarch64 | arm64)
+      S5CMD_ARCH="arm64"
+      S5CMD_SHA256="1439f0d00ecedcd2a2f1f2c6749bbb0152b2257bf5086f29646ec8ae38798e24"
+      ;;
+    *)
+      echo "ERROR: s5cmd has no configured binary for architecture $(uname -m)" >&2
+      exit 1
+      ;;
+  esac
+  archive="$(mktemp)"
+  trap 'rm -f "${archive:-}"' EXIT
+  curl --fail --silent --show-error --location --retry 3 \
+    --output "${archive}" \
+    "https://github.com/peak/s5cmd/releases/download/v2.3.0/s5cmd_2.3.0_Linux-${S5CMD_ARCH}.tar.gz"
+  printf '%s  %s\n' "${S5CMD_SHA256}" "${archive}" | sha256sum --check --status || {
+    echo "ERROR: downloaded s5cmd archive failed its SHA-256 check" >&2
+    exit 1
+  }
+  tar xzf "${archive}" -C "${BIN_DIR}" s5cmd
+  chmod 755 "${S5CMD}"
+  rm -f "${archive}"
+  trap - EXIT
+fi
+export PATH="${BIN_DIR}:${PATH}"
+
+echo "Verifying Nebius Object Storage access with the checkpoint credentials..."
+set -a
+# shellcheck disable=SC1090 # generated installation-specific environment file
+source "${ENV_FILE}"
+set +a
+"${VENV_DIR}/bin/python" - <<'EOF'
+import os
+import socket
+import uuid
+
+import boto3
+from botocore.config import Config
+
+endpoint = os.environ["NEBIUS_OBJECT_STORAGE_ENDPOINT"]
+bucket = os.environ["NEBIUS_CHECKPOINT_BUCKET"]
+region = os.environ["NEBIUS_OBJECT_STORAGE_REGION"]
+object_storage = boto3.client(
+    "s3",
+    endpoint_url=endpoint,
+    region_name=region,
+    config=Config(
+        s3={"addressing_style": "path"},
+        retries={"max_attempts": 5, "mode": "standard"},
+    ),
+)
+key = f".ml-cookbook/setup-check/{socket.gethostname()}-{os.getpid()}-{uuid.uuid4().hex}"
+created = False
+try:
+    object_storage.put_object(Bucket=bucket, Key=key, Body=b"ok")
+    created = True
+    if object_storage.get_object(Bucket=bucket, Key=key)["Body"].read() != b"ok":
+        raise RuntimeError("Object Storage setup probe returned unexpected content")
+finally:
+    if created:
+        object_storage.delete_object(Bucket=bucket, Key=key)
+print(f"Nebius Object Storage access OK: bucket={bucket} endpoint={endpoint}")
+EOF
+
+"${VENV_DIR}/bin/python" -c 'import torch, s3torchconnector.dcp; print("torch", torch.__version__, "/ s3torchconnector DCP import OK")'
+echo "Setup done."

--- a/slurm/object-storage-checkpointing/setup.sh
+++ b/slurm/object-storage-checkpointing/setup.sh
@@ -25,8 +25,8 @@ require_command curl "Ask the operator to install curl on the login node."
 require_command tar "Ask the operator to install tar on the login node."
 require_command sha256sum "Ask the operator to install GNU coreutils on the login node."
 require_command flock "Ask the operator to install util-linux on the login node."
-if ! python3 -c 'import sys; raise SystemExit(sys.version_info < (3, 10))'; then
-  echo "ERROR: Python 3.10 or newer is required on the login node." >&2
+if ! python3 -c 'import sys; raise SystemExit(sys.version_info < (3, 11))'; then
+  echo "ERROR: Python 3.11 or newer is required on the login node." >&2
   exit 1
 fi
 

--- a/slurm/object-storage-checkpointing/setup.sh
+++ b/slurm/object-storage-checkpointing/setup.sh
@@ -7,6 +7,8 @@ CHECKPOINTING_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 VENV_DIR="${CHECKPOINTING_DIR}/.env"
 ENV_FILE='/etc/nebius-checkpoints.env'
 BIN_DIR="${CHECKPOINTING_DIR}/bin"
+SETUP_LOCK="${CHECKPOINTING_DIR}/.setup.lock"
+PIP_VERSION='26.1.2'
 
 require_command() {
   if ! command -v "$1" >/dev/null; then
@@ -19,8 +21,18 @@ require_command python3 "Install Python 3 with the venv module on the login node
 require_command curl "Install curl on the login node."
 require_command tar "Install tar on the login node."
 require_command sha256sum "Install GNU coreutils on the login node."
+require_command flock "Install util-linux on the login node."
 if ! python3 -c 'import sys; raise SystemExit(sys.version_info < (3, 10))'; then
   echo "ERROR: Python 3.10 or newer is required on the login node." >&2
+  exit 1
+fi
+
+# The environment and helper binary live on the shared jail. Refuse concurrent
+# setup runs rather than letting two pip/tar processes corrupt the same paths.
+exec 9>"${SETUP_LOCK}"
+if ! flock -n 9; then
+  echo "ERROR: another checkpointing setup is already running in ${CHECKPOINTING_DIR}." >&2
+  echo "Wait for it to finish, then run setup.sh again." >&2
   exit 1
 fi
 
@@ -44,7 +56,7 @@ if [ ! -d "${VENV_DIR}" ]; then
 fi
 
 echo "Installing pinned dependencies (torch download is large, be patient)..."
-"${VENV_DIR}/bin/pip" install --quiet --upgrade pip
+"${VENV_DIR}/bin/pip" install --quiet --upgrade "pip==${PIP_VERSION}"
 "${VENV_DIR}/bin/pip" install --quiet --requirement "${CHECKPOINTING_DIR}/requirements.txt"
 
 S5CMD="${BIN_DIR}/s5cmd"
@@ -76,6 +88,7 @@ if [ ! -x "${S5CMD}" ]; then
   archive="$(mktemp)"
   trap 'rm -f "${archive:-}"' EXIT
   curl --fail --silent --show-error --location --retry 3 \
+    --connect-timeout 10 --max-time 300 \
     --output "${archive}" \
     "https://github.com/peak/s5cmd/releases/download/v2.3.0/s5cmd_2.3.0_Linux-${S5CMD_ARCH}.tar.gz"
   printf '%s  %s\n' "${S5CMD_SHA256}" "${archive}" | sha256sum --check --status || {
@@ -110,6 +123,8 @@ object_storage = boto3.client(
     endpoint_url=endpoint,
     region_name=region,
     config=Config(
+        connect_timeout=10,
+        read_timeout=60,
         s3={"addressing_style": "path"},
         retries={"max_attempts": 5, "mode": "standard"},
     ),

--- a/slurm/object-storage-checkpointing/setup.sh
+++ b/slurm/object-storage-checkpointing/setup.sh
@@ -17,11 +17,14 @@ require_command() {
   fi
 }
 
-require_command python3 "Install Python 3 with the venv module on the login node."
-require_command curl "Install curl on the login node."
-require_command tar "Install tar on the login node."
-require_command sha256sum "Install GNU coreutils on the login node."
-require_command flock "Install util-linux on the login node."
+# Standard Soperator 4.1.x jails provide these tools. Keep explicit checks so a
+# custom or older jail fails with an actionable message instead of halfway
+# through setup.
+require_command python3 "Ask the operator to install Python 3 with the venv module."
+require_command curl "Ask the operator to install curl on the login node."
+require_command tar "Ask the operator to install tar on the login node."
+require_command sha256sum "Ask the operator to install GNU coreutils on the login node."
+require_command flock "Ask the operator to install util-linux on the login node."
 if ! python3 -c 'import sys; raise SystemExit(sys.version_info < (3, 10))'; then
   echo "ERROR: Python 3.10 or newer is required on the login node." >&2
   exit 1
@@ -40,10 +43,10 @@ fi
 # output directory during setup rather than requiring a manual extra step.
 mkdir -p "${CHECKPOINTING_DIR}/outputs" "${BIN_DIR}"
 
-if [ ! -f "${ENV_FILE}" ]; then
-  echo "ERROR: ${ENV_FILE} not found." >&2
+if [ ! -r "${ENV_FILE}" ]; then
+  echo "ERROR: ${ENV_FILE} is missing or not readable by $(id -un)." >&2
   echo "It is created from the jail-checkpoints k8s secret (checkpoints_access module)." >&2
-  echo "Make sure checkpoint_storage_enabled = true in your Terraform installation." >&2
+  echo "Ask the operator to enable checkpoint storage and grant your Slurm user read access." >&2
   exit 1
 fi
 

--- a/slurm/object-storage-checkpointing/tests/test_checkpoint_retention.py
+++ b/slurm/object-storage-checkpointing/tests/test_checkpoint_retention.py
@@ -1,0 +1,31 @@
+import unittest
+
+from checkpoint_retention import plan_checkpoint_pruning
+
+
+class CheckpointRetentionTests(unittest.TestCase):
+    def test_keep_all_committed_still_removes_stale_partials(self):
+        self.assertEqual(
+            plan_checkpoint_pruning({10, 20, 30}, committed_step=20, keep_last=0),
+            [(30, "stale partial")],
+        )
+
+    def test_retention_keeps_newest_committed_steps(self):
+        self.assertEqual(
+            plan_checkpoint_pruning({10, 20, 30}, committed_step=30, keep_last=2),
+            [(10, "retention")],
+        )
+
+    def test_stale_partials_do_not_count_toward_retention(self):
+        self.assertEqual(
+            plan_checkpoint_pruning({10, 20, 30, 40}, committed_step=30, keep_last=2),
+            [(40, "stale partial"), (10, "retention")],
+        )
+
+    def test_negative_retention_is_rejected(self):
+        with self.assertRaisesRegex(ValueError, "non-negative"):
+            plan_checkpoint_pruning({10}, committed_step=10, keep_last=-1)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/slurm/object-storage-checkpointing/train_fsdp.py
+++ b/slurm/object-storage-checkpointing/train_fsdp.py
@@ -38,6 +38,7 @@ import torch.distributed as dist
 import torch.distributed.checkpoint as dcp
 import torch.nn as nn
 from botocore.config import Config
+from checkpoint_retention import plan_checkpoint_pruning
 from s3torchconnector import S3ClientConfig
 from s3torchconnector.dcp import S3StorageReader, S3StorageWriter
 from torch.distributed.checkpoint.state_dict import get_state_dict, set_state_dict
@@ -176,8 +177,6 @@ class ObjectStorageCheckpointManager:
         Counting partials toward retention would let a killed high-numbered save
         push the marker's own checkpoint out of the keep window.
         """
-        if keep_last <= 0:
-            return
         steps = set()
         step_prefix_re = re.compile(rf"^{re.escape(self.prefix)}/step-([0-9]+)/$")
         paginator = self._object_storage.get_paginator("list_objects_v2")
@@ -188,10 +187,7 @@ class ObjectStorageCheckpointManager:
                 match = step_prefix_re.fullmatch(cp["Prefix"])
                 if match:
                     steps.add(int(match.group(1)))
-        stale_partials = sorted(s for s in steps if s > committed_step)
-        committed = sorted(s for s in steps if s <= committed_step)
-        doomed = [(s, "stale partial") for s in stale_partials]
-        doomed += [(s, "retention") for s in committed[:-keep_last]]
+        doomed = plan_checkpoint_pruning(steps, committed_step, keep_last)
         for step, reason in doomed:
             keys = []
             for page in paginator.paginate(
@@ -212,6 +208,17 @@ class ObjectStorageCheckpointManager:
                         f"{first.get('Message', 'no message')}"
                     )
             log(f"pruned checkpoint step {step} ({reason}, {len(keys)} objects)")
+
+    def _prune_best_effort(self, committed_step: int) -> None:
+        """Prune after commit without misreporting housekeeping as data loss."""
+        try:
+            self._prune(self.keep_last, committed_step)
+        except Exception as exc:  # noqa: BLE001 - warn and retry after the next commit
+            log(
+                "WARNING: retention prune failed after checkpoint "
+                f"step {committed_step} was committed (prefix={self.prefix}): "
+                f"{type(exc).__name__}: {exc}"
+            )
 
     def wait_pending(self) -> None:
         """Wait until the in-flight upload (if any) is finished and committed.
@@ -266,27 +273,32 @@ class ObjectStorageCheckpointManager:
                     log(
                         f"checkpoint step {step}: upload finished in {upload_s:.1f}s, marker committed"
                     )
-                    self._prune(self.keep_last, step)
             except BaseException as exc:  # noqa: BLE001 - DCP uses BaseException
                 self._commit_error = exc
+                return
+            if rank == 0:
+                self._prune_best_effort(step)
 
         self._pending = threading.Thread(target=_commit, daemon=True)
         self._pending.start()
         return blocked_s
 
     def save_sync(self, state_dict: dict, step: int) -> None:
-        """Blocking save + marker commit (used for the final/SIGTERM save)."""
+        """Blocking save + marker commit (used for the final/signal save)."""
         self.wait_pending()
+        t0 = time.perf_counter()
         dcp.save(state_dict, storage_writer=self._writer(step))
         commit_error = None
         if dist.get_rank() == 0:
             try:
                 self._write_marker(step)
-                self._prune(self.keep_last, step)
             except Exception as exc:  # noqa: BLE001 - propagated collectively below
                 commit_error = exc
-        self._raise_if_any_rank_failed(commit_error, "synchronous checkpoint commit failed")
-        log(f"checkpoint step {step}: synchronous save committed")
+        self._raise_if_any_rank_failed(commit_error, "synchronous marker commit failed")
+        save_s = time.perf_counter() - t0
+        log(f"checkpoint step {step}: synchronous save committed in {save_s:.1f}s")
+        if dist.get_rank() == 0:
+            self._prune_best_effort(step)
 
     def load(self, model, optimizer, step: int) -> None:
         reader = S3StorageReader(

--- a/slurm/object-storage-checkpointing/train_fsdp.py
+++ b/slurm/object-storage-checkpointing/train_fsdp.py
@@ -1,0 +1,548 @@
+#!/usr/bin/env python3
+"""FSDP2 training example that checkpoints to Nebius Object Storage.
+
+Demonstrates the recommended checkpointing pattern for Soperator clusters:
+
+- FSDP2-sharded model/optimizer state + PyTorch Distributed Checkpoint (DCP):
+  every rank uploads only its own shard, directly to Object Storage
+  (no shared-FS staging, no rank-0 gather).
+- ``dcp.async_save``: training blocks only for the GPU->host staging (typically
+  well under a second), the upload happens in the background.
+- Atomic-commit protocol: a checkpoint only "exists" once the small ``latest``
+  marker object points at it. Jobs killed mid-upload never corrupt the resume
+  path - the marker still points at the previous complete checkpoint.
+- Auto-resume: on start, the script reads the marker and continues from the
+  latest complete checkpoint if one exists. To start over, use a new prefix
+  (the default prefix is already unique per submission).
+
+Credentials/endpoint come from the environment (see checkpoint_train.sh,
+which sources /etc/nebius-checkpoints.env delivered by the Soperator
+checkpointing infrastructure):
+    AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY (S3-protocol SDK compatibility),
+    NEBIUS_OBJECT_STORAGE_ENDPOINT, NEBIUS_OBJECT_STORAGE_REGION,
+    NEBIUS_CHECKPOINT_BUCKET
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import re
+import signal
+import threading
+import time
+
+import boto3
+import torch
+import torch.distributed as dist
+import torch.distributed.checkpoint as dcp
+import torch.nn as nn
+from botocore.config import Config
+from s3torchconnector import S3ClientConfig
+from s3torchconnector.dcp import S3StorageReader, S3StorageWriter
+from torch.distributed.checkpoint.state_dict import get_state_dict, set_state_dict
+from torch.distributed.fsdp import fully_shard
+
+CHECKPOINT_PREFIX_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._/-]*$")
+
+
+def log(msg: str) -> None:
+    if int(os.environ.get("RANK", "0")) == 0:
+        print(f"[{time.strftime('%H:%M:%S')}] {msg}", flush=True)
+
+
+class CheckpointDemoModel(nn.Sequential):
+    def forward(self, inputs: torch.Tensor) -> torch.Tensor:
+        # The outer FSDP2 wrapper requires a non-view output so its backward
+        # hook cannot be lost if downstream code later performs an in-place op.
+        return super().forward(inputs).clone()
+
+
+def build_model(hidden: int, layers: int) -> nn.Module:
+    return CheckpointDemoModel(
+        nn.Embedding(1024, hidden),
+        *[
+            nn.TransformerEncoderLayer(
+                hidden,
+                8,
+                hidden * 4,
+                dropout=0.0,
+                batch_first=True,
+            )
+            for _ in range(layers)
+        ],
+        nn.Linear(hidden, 1024),
+    )
+
+
+class ObjectStorageCheckpointManager:
+    """Async DCP checkpoints to Nebius Object Storage with an atomic marker."""
+
+    def __init__(
+        self,
+        bucket: str,
+        prefix: str,
+        region: str,
+        endpoint: str,
+        control_group,
+        keep_last: int = 3,
+    ):
+        self.bucket = bucket
+        self.prefix = prefix.strip("/")
+        self.region = region
+        self.endpoint = endpoint
+        self.keep_last = keep_last
+        self.control_group = control_group
+        self.s3client_config = S3ClientConfig(force_path_style=True)
+        # boto3 is only used for the tiny marker and retention operations.
+        self._object_storage = boto3.client(
+            "s3",
+            endpoint_url=endpoint,
+            region_name=region,
+            config=Config(
+                s3={"addressing_style": "path"},
+                retries={"max_attempts": 5, "mode": "standard"},
+            ),
+        )
+        self._pending: threading.Thread | None = None
+        # PyTorch DCP's CheckpointException derives directly from BaseException,
+        # not Exception. Keep the wider type so upload failures cannot escape the
+        # background thread and let training continue without persistence.
+        self._commit_error: BaseException | None = None
+
+    def _step_uri(self, step: int) -> str:
+        return f"s3://{self.bucket}/{self.prefix}/step-{step:08d}/"
+
+    def _writer(self, step: int) -> S3StorageWriter:
+        return S3StorageWriter(
+            region=self.region,
+            path=self._step_uri(step),
+            s3client_config=self.s3client_config,
+        )
+
+    def read_marker(self):
+        """Return the committed step, or None if no checkpoint exists.
+
+        Only a definitive "key does not exist" means no checkpoint. Any other
+        error (network, throttling, auth) is retried and then raised: treating
+        a transient read failure as "no checkpoint" would silently restart
+        training from scratch.
+        """
+        last_err = None
+        for attempt in range(5):
+            try:
+                body = self._object_storage.get_object(
+                    Bucket=self.bucket, Key=f"{self.prefix}/latest"
+                )["Body"].read()
+                break
+            except self._object_storage.exceptions.NoSuchKey:
+                return None
+            except Exception as e:  # noqa: BLE001 - retried, then re-raised below
+                code = getattr(e, "response", {}).get("Error", {}).get("Code", "")
+                if code in ("NoSuchKey", "NotFound", "404"):
+                    return None
+                last_err = e
+                if attempt < 4:
+                    time.sleep(2**attempt)
+        else:
+            raise RuntimeError(
+                f"cannot read checkpoint marker (refusing to start fresh): {last_err}"
+            )
+
+        try:
+            text = body.decode("ascii").strip()
+        except UnicodeDecodeError as exc:
+            raise RuntimeError("checkpoint marker is not ASCII") from exc
+        if not text.isdigit():
+            raise RuntimeError(f"checkpoint marker is not a non-negative integer: {text!r}")
+        return int(text)
+
+    def _write_marker(self, step: int) -> None:
+        self._object_storage.put_object(
+            Bucket=self.bucket,
+            Key=f"{self.prefix}/latest",
+            Body=str(step).encode(),
+        )
+
+    def _prune(self, keep_last: int, committed_step: int) -> None:
+        """Retention, driven by the just-committed marker step.
+
+        Runs only while no save is in flight (saves are serialized), so:
+        - steps ABOVE the marker are leftovers of killed/aborted uploads - garbage;
+        - retention counts only steps at or below the marker (committed history);
+        - the marker target is the newest committed step and is always kept.
+        Counting partials toward retention would let a killed high-numbered save
+        push the marker's own checkpoint out of the keep window.
+        """
+        if keep_last <= 0:
+            return
+        steps = set()
+        step_prefix_re = re.compile(rf"^{re.escape(self.prefix)}/step-([0-9]+)/$")
+        paginator = self._object_storage.get_paginator("list_objects_v2")
+        for page in paginator.paginate(
+            Bucket=self.bucket, Prefix=f"{self.prefix}/step-", Delimiter="/"
+        ):
+            for cp in page.get("CommonPrefixes", []):
+                match = step_prefix_re.fullmatch(cp["Prefix"])
+                if match:
+                    steps.add(int(match.group(1)))
+        stale_partials = sorted(s for s in steps if s > committed_step)
+        committed = sorted(s for s in steps if s <= committed_step)
+        doomed = [(s, "stale partial") for s in stale_partials]
+        doomed += [(s, "retention") for s in committed[:-keep_last]]
+        for step, reason in doomed:
+            keys = []
+            for page in paginator.paginate(
+                Bucket=self.bucket, Prefix=f"{self.prefix}/step-{step:08d}/"
+            ):
+                keys += [{"Key": o["Key"]} for o in page.get("Contents", [])]
+            for i in range(0, len(keys), 1000):
+                response = self._object_storage.delete_objects(
+                    Bucket=self.bucket,
+                    Delete={"Objects": keys[i : i + 1000]},
+                )
+                errors = response.get("Errors", [])
+                if errors:
+                    first = errors[0]
+                    raise RuntimeError(
+                        f"failed to delete {len(errors)} checkpoint objects at step {step}; "
+                        f"first error: {first.get('Code', 'unknown')}: "
+                        f"{first.get('Message', 'no message')}"
+                    )
+            log(f"pruned checkpoint step {step} ({reason}, {len(keys)} objects)")
+
+    def wait_pending(self) -> None:
+        """Wait until the in-flight upload (if any) is finished and committed.
+
+        Raises if the background upload/commit failed: a checkpoint that
+        silently stops persisting is lost progress waiting to happen.
+        """
+        if self._pending is not None:
+            self._pending.join()
+            self._pending = None
+        self._raise_if_any_rank_failed(
+            self._commit_error,
+            "background checkpoint upload/commit failed",
+        )
+
+    def _raise_if_any_rank_failed(self, local_error: BaseException | None, message: str) -> None:
+        """Make a rank-local persistence error fatal on every training rank.
+
+        Without this rendezvous, the failing rank raises while its peers enter the
+        next DCP collective, turning an actionable upload error into a hung job.
+        The dedicated Gloo group is never used by async DCP.
+        """
+        failed = torch.tensor(1 if local_error is not None else 0, dtype=torch.int32)
+        dist.all_reduce(failed, op=dist.ReduceOp.MAX, group=self.control_group)
+        if not failed.item():
+            return
+        if local_error is not None:
+            raise RuntimeError(message) from local_error
+        raise RuntimeError(f"{message} on another rank")
+
+    def save_async(self, state_dict: dict, step: int) -> float:
+        """Start an async save; returns the training-blocking time in seconds.
+
+        The `latest` marker is committed from a background thread as soon as the
+        upload completes - independent of the training loop.
+        """
+        # Only one save in flight: wait for the previous one first.
+        self.wait_pending()
+        rank = dist.get_rank()
+        t0 = time.perf_counter()
+        future = dcp.async_save(state_dict, storage_writer=self._writer(step))
+        blocked_s = time.perf_counter() - t0
+
+        def _commit():
+            try:
+                future.result()
+                # Rank 0 coordinates DCP's final .metadata write, so its future
+                # resolving means the checkpoint is globally complete.
+                if rank == 0:
+                    self._write_marker(step)
+                    upload_s = time.perf_counter() - t0
+                    log(
+                        f"checkpoint step {step}: upload finished in {upload_s:.1f}s, marker committed"
+                    )
+                    self._prune(self.keep_last, step)
+            except BaseException as exc:  # noqa: BLE001 - DCP uses BaseException
+                self._commit_error = exc
+
+        self._pending = threading.Thread(target=_commit, daemon=True)
+        self._pending.start()
+        return blocked_s
+
+    def save_sync(self, state_dict: dict, step: int) -> None:
+        """Blocking save + marker commit (used for the final/SIGTERM save)."""
+        self.wait_pending()
+        dcp.save(state_dict, storage_writer=self._writer(step))
+        commit_error = None
+        if dist.get_rank() == 0:
+            try:
+                self._write_marker(step)
+                self._prune(self.keep_last, step)
+            except Exception as exc:  # noqa: BLE001 - propagated collectively below
+                commit_error = exc
+        self._raise_if_any_rank_failed(commit_error, "synchronous checkpoint commit failed")
+        log(f"checkpoint step {step}: synchronous save committed")
+
+    def load(self, model, optimizer, step: int) -> None:
+        reader = S3StorageReader(
+            region=self.region,
+            path=self._step_uri(step),
+            s3client_config=self.s3client_config,
+        )
+        model_sd, optim_sd = get_state_dict(model, optimizer)
+        extra = {"step": torch.tensor(0)}
+        dcp.load(
+            {"model": model_sd, "optim": optim_sd, "extra": extra},
+            storage_reader=reader,
+        )
+        loaded_step = int(extra["step"].item())
+        if loaded_step != step:
+            raise RuntimeError(
+                f"checkpoint payload says step {loaded_step}, but its marker says step {step}"
+            )
+        set_state_dict(model, optimizer, model_state_dict=model_sd, optim_state_dict=optim_sd)
+
+
+def validate_checkpoint_prefix(value: str) -> str:
+    prefix = value.strip().strip("/")
+    if not prefix or not CHECKPOINT_PREFIX_RE.fullmatch(prefix):
+        raise ValueError("must contain only letters, digits, '.', '_', '-', and '/'")
+    if any(part in ("", ".", "..") for part in prefix.split("/")):
+        raise ValueError("contains an unsafe path segment")
+    return prefix
+
+
+def run_on_rank_zero(operation, description: str, control_group):
+    """Run an Object Storage control-plane operation once and broadcast its result."""
+    local_error = None
+    result = None
+    if dist.get_rank() == 0:
+        try:
+            result = operation()
+        except Exception as exc:  # noqa: BLE001 - serialized for every peer below
+            local_error = exc
+    payload = [
+        result,
+        None if local_error is None else f"{type(local_error).__name__}: {local_error}",
+    ]
+    dist.broadcast_object_list(payload, src=0, group=control_group)
+    if payload[1] is not None:
+        if local_error is not None:
+            raise RuntimeError(f"{description} failed on rank 0") from local_error
+        raise RuntimeError(f"{description} failed on rank 0: {payload[1]}")
+    return payload[0]
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--hidden", type=int, default=1024)
+    parser.add_argument("--layers", type=int, default=8)
+    parser.add_argument("--batch-size", type=int, default=8)
+    parser.add_argument("--seq-len", type=int, default=512)
+    parser.add_argument("--steps", type=int, default=10_000_000, help="Stop after this many steps.")
+    parser.add_argument(
+        "--save-every-seconds",
+        type=float,
+        default=120.0,
+        help="Checkpoint cadence. See README for how to size this (Young/Daly).",
+    )
+    parser.add_argument(
+        "--save-every-steps",
+        type=int,
+        default=None,
+        help="Optional step-based cadence; overrides --save-every-seconds.",
+    )
+    parser.add_argument(
+        "--prefix",
+        default=None,
+        help="Key prefix inside the bucket. Defaults to <job name>-<job id>, which "
+        "isolates independent submissions from each other while staying stable "
+        "across requeues of the same job. Pass an explicit prefix to deliberately "
+        "resume across separate submissions or from another cluster.",
+    )
+    parser.add_argument(
+        "--keep-last",
+        type=int,
+        default=3,
+        help="Retention: keep this many newest checkpoints, prune older ones (0 keeps all).",
+    )
+    args = parser.parse_args()
+
+    if args.hidden <= 0 or args.hidden % 8:
+        parser.error("--hidden must be a positive multiple of the model's 8 attention heads")
+    if min(args.layers, args.batch_size, args.seq_len, args.steps) <= 0:
+        parser.error("--layers, --batch-size, --seq-len, and --steps must be positive")
+    if args.save_every_seconds <= 0:
+        parser.error("--save-every-seconds must be positive")
+    if args.save_every_steps is not None and args.save_every_steps <= 0:
+        parser.error("--save-every-steps must be positive")
+    if args.keep_last < 0:
+        parser.error("--keep-last must be non-negative")
+
+    bucket = os.environ.get("NEBIUS_CHECKPOINT_BUCKET", "").strip()
+    endpoint = os.environ.get("NEBIUS_OBJECT_STORAGE_ENDPOINT", "").strip()
+    region = os.environ.get("NEBIUS_OBJECT_STORAGE_REGION", "").strip() or "eu-north1"
+    if not bucket:
+        parser.error("NEBIUS_CHECKPOINT_BUCKET is required")
+    if not endpoint:
+        parser.error("NEBIUS_OBJECT_STORAGE_ENDPOINT is required")
+
+    # s3torchconnector 1.5's DCP reader/writer do not accept an endpoint
+    # argument. Their native client reads this standard compatibility variable
+    # when it is constructed, so derive it from the authoritative Nebius value
+    # instead of depending on an installation-specific alias.
+    os.environ["AWS_ENDPOINT_URL"] = endpoint
+
+    if args.prefix is None:
+        job_name = os.environ.get("SLURM_JOB_NAME", "checkpointing-demo")
+        job_id = os.environ.get("SLURM_JOB_ID")
+        # Job ID survives requeues (unattended resume keeps working) but differs
+        # between submissions (no accidental sharing of `latest` between runs).
+        args.prefix = f"{job_name}-{job_id}" if job_id else job_name
+    try:
+        args.prefix = validate_checkpoint_prefix(args.prefix)
+    except ValueError as exc:
+        parser.error(f"invalid --prefix: {exc}")
+
+    # async_save stages via a CPU (gloo) process group alongside NCCL.
+    dist.init_process_group(backend="cpu:gloo,cuda:nccl")
+    rank = dist.get_rank()
+    local_rank = int(os.environ["LOCAL_RANK"])
+    torch.cuda.set_device(local_rank)
+    device = torch.device("cuda", local_rank)
+    # DCP async saves use the default group's Gloo backend from a background
+    # thread. Keep main-thread control collectives on a separate process group
+    # so their ordering cannot interleave with DCP collectives across ranks.
+    control_group = dist.new_group(backend="gloo")
+
+    # FSDP2 (fully_shard): model and optimizer state are sharded across ranks, so
+    # every rank checkpoints only its own shard - this is what makes the DCP
+    # saves in this example genuinely parallel per-rank uploads.
+    # Initialize identical parameters on every rank. Dropout is disabled in the
+    # toy model because this example does not include per-rank RNG state in DCP.
+    torch.manual_seed(0)
+    torch.cuda.manual_seed_all(0)
+    model = build_model(args.hidden, args.layers).to(device)
+    n_params = sum(p.numel() for p in model.parameters())
+    for module in model:
+        if isinstance(module, nn.TransformerEncoderLayer):
+            fully_shard(module)
+    fully_shard(model)
+    optimizer = torch.optim.AdamW(model.parameters(), lr=1e-4)
+    log(
+        f"world={dist.get_world_size()} params={n_params / 1e6:.0f}M (FSDP2-sharded) "
+        f"checkpoint~{n_params * 12 / 1e9:.1f}GB bucket={bucket} prefix={args.prefix}"
+    )
+
+    ckpt = ObjectStorageCheckpointManager(
+        bucket,
+        args.prefix,
+        region,
+        endpoint,
+        control_group,
+        keep_last=args.keep_last,
+    )
+
+    # Resume from the latest complete checkpoint under the prefix.
+    start_step = 0
+    marker = run_on_rank_zero(ckpt.read_marker, "checkpoint marker read", control_group)
+    last_checkpoint_step = marker
+    if marker is not None:
+        log(f"resuming from checkpoint step {marker}")
+        ckpt.load(model, optimizer, marker)
+        start_step = marker
+    else:
+        log("no checkpoint found, starting fresh")
+
+    # On SIGTERM/SIGUSR1: commit the current step so no progress is lost, then
+    # exit non-zero. Automatic requeue still depends on
+    # the scheduler event and site policy; a user cancellation is not requeued.
+    stop_requested = {"flag": False}
+
+    def _stop_handler(_signum, _frame):
+        stop_requested["flag"] = True
+
+    signal.signal(signal.SIGTERM, _stop_handler)
+    signal.signal(signal.SIGUSR1, _stop_handler)
+
+    loss_fn = nn.CrossEntropyLoss()
+    last_save = time.monotonic()
+    step = start_step
+    stop_now = False
+
+    while step < args.steps and not stop_now:
+        step += 1
+        # Fresh batch each step (seeded by step for reproducibility across resume).
+        gen = torch.Generator(device="cpu").manual_seed(step * dist.get_world_size() + rank)
+        data = torch.randint(0, 1024, (args.batch_size, args.seq_len), generator=gen).to(device)
+        optimizer.zero_grad(set_to_none=True)
+        out = model(data)
+        loss = loss_fn(out.view(-1, 1024), data.view(-1))
+        loss.backward()
+        optimizer.step()
+
+        # Save/stop decisions must be identical on every rank: DCP saves and the
+        # final checkpoint are collective operations, so a rank acting alone
+        # (wall-clock skew, a signal delivered to only some ranks yet) would hang
+        # the job. Rank 0 decides saves; stop requests are OR-reduced. The
+        # all_reduce runs on a dedicated Gloo group that async DCP never uses.
+        control = torch.zeros(2, dtype=torch.int32)
+        if rank == 0:
+            due = (args.save_every_steps is not None and step % args.save_every_steps == 0) or (
+                args.save_every_steps is None
+                and time.monotonic() - last_save >= args.save_every_seconds
+            )
+            control[0] = 1 if due else 0
+        control[1] = 1 if stop_requested["flag"] else 0
+        dist.all_reduce(control, op=dist.ReduceOp.MAX, group=control_group)
+
+        if control[0]:
+            model_sd, optim_sd = get_state_dict(model, optimizer)
+            state = {
+                "model": model_sd,
+                "optim": optim_sd,
+                "extra": {"step": torch.tensor(step)},
+            }
+            blocked_s = ckpt.save_async(state, step)
+            last_checkpoint_step = step
+            last_save = time.monotonic()
+            log(
+                f"step {step} loss {loss.item():.4f}: async_save blocked training for {blocked_s * 1000:.0f}ms"
+            )
+        elif step % 50 == 0:
+            log(f"step {step} loss {loss.item():.4f}")
+        if control[1]:
+            log("stop signal observed at a safe step boundary; checkpointing before exit")
+        stop_now = bool(control[1])
+
+    # Final checkpoint: synchronous unless this exact step is already being
+    # persisted. Never rewrite a prefix that `latest` may already reference: a
+    # kill during that redundant overwrite could corrupt the committed target.
+    if last_checkpoint_step == step:
+        ckpt.wait_pending()
+        log(f"checkpoint step {step}: existing save committed; skipped duplicate final write")
+    else:
+        model_sd, optim_sd = get_state_dict(model, optimizer)
+        ckpt.save_sync(
+            {
+                "model": model_sd,
+                "optim": optim_sd,
+                "extra": {"step": torch.tensor(step)},
+            },
+            step,
+        )
+
+    dist.barrier()
+    dist.destroy_process_group(control_group)
+    dist.destroy_process_group()
+    if stop_now:
+        log(f"exiting after signal at step {step} (checkpoint committed)")
+        raise SystemExit(143)
+    log(f"finished at step {step}")
+
+
+if __name__ == "__main__":
+    main()

--- a/slurm/object-storage-checkpointing/train_fsdp.py
+++ b/slurm/object-storage-checkpointing/train_fsdp.py
@@ -100,6 +100,8 @@ class ObjectStorageCheckpointManager:
             endpoint_url=endpoint,
             region_name=region,
             config=Config(
+                connect_timeout=10,
+                read_timeout=60,
                 s3={"addressing_style": "path"},
                 retries={"max_attempts": 5, "mode": "standard"},
             ),
@@ -457,13 +459,15 @@ def main() -> None:
     else:
         log("no checkpoint found, starting fresh")
 
-    # On SIGTERM/SIGUSR1: commit the current step so no progress is lost, then
-    # exit non-zero. Automatic requeue still depends on
+    # On SIGTERM/SIGUSR1: remember the first signal, commit the current step so
+    # no progress is lost, then exit with its conventional signal-derived code.
+    # Automatic requeue still depends on
     # the scheduler event and site policy; a user cancellation is not requeued.
-    stop_requested = {"flag": False}
+    stop_requested = {"signum": None}
 
-    def _stop_handler(_signum, _frame):
-        stop_requested["flag"] = True
+    def _stop_handler(signum, _frame):
+        if stop_requested["signum"] is None:
+            stop_requested["signum"] = signum
 
     signal.signal(signal.SIGTERM, _stop_handler)
     signal.signal(signal.SIGUSR1, _stop_handler)
@@ -472,6 +476,7 @@ def main() -> None:
     last_save = time.monotonic()
     step = start_step
     stop_now = False
+    stop_signal = None
 
     while step < args.steps and not stop_now:
         step += 1
@@ -496,7 +501,7 @@ def main() -> None:
                 and time.monotonic() - last_save >= args.save_every_seconds
             )
             control[0] = 1 if due else 0
-        control[1] = 1 if stop_requested["flag"] else 0
+        control[1] = stop_requested["signum"] or 0
         dist.all_reduce(control, op=dist.ReduceOp.MAX, group=control_group)
 
         if control[0]:
@@ -515,8 +520,10 @@ def main() -> None:
         elif step % 50 == 0:
             log(f"step {step} loss {loss.item():.4f}")
         if control[1]:
-            log("stop signal observed at a safe step boundary; checkpointing before exit")
-        stop_now = bool(control[1])
+            stop_signal = int(control[1].item())
+            signal_name = signal.Signals(stop_signal).name
+            log(f"{signal_name} observed at a safe step boundary; checkpointing before exit")
+        stop_now = stop_signal is not None
 
     # Final checkpoint: synchronous unless this exact step is already being
     # persisted. Never rewrite a prefix that `latest` may already reference: a
@@ -538,9 +545,10 @@ def main() -> None:
     dist.barrier()
     dist.destroy_process_group(control_group)
     dist.destroy_process_group()
-    if stop_now:
-        log(f"exiting after signal at step {step} (checkpoint committed)")
-        raise SystemExit(143)
+    if stop_signal is not None:
+        signal_name = signal.Signals(stop_signal).name
+        log(f"exiting after {signal_name} at step {step} (checkpoint committed)")
+        raise SystemExit(128 + stop_signal)
     log(f"finished at step {step}")
 
 

--- a/slurm/object-storage-checkpointing/verify.sh
+++ b/slurm/object-storage-checkpointing/verify.sh
@@ -33,6 +33,7 @@ export PATH="${CHECKPOINTING_DIR}/bin:${PATH}"
 START_DEADLINE="${VERIFY_START_DEADLINE:-1800}"   # submit -> job running
 COMMIT_DEADLINE="${VERIFY_COMMIT_DEADLINE:-300}"  # running -> first commit
 RESUME_DEADLINE="${VERIFY_RESUME_DEADLINE:-300}"  # resume -> next commit
+CLEANUP_DEADLINE="${VERIFY_CLEANUP_DEADLINE:-120}" # cancellation -> absent from squeue
 
 ENV_FILE='/etc/nebius-checkpoints.env'
 if [ ! -r "${ENV_FILE}" ]; then
@@ -58,9 +59,34 @@ pass() {
 JOB_IDS=()
 PREFIX=""
 cleanup() {
+  local all_jobs_gone=true job waited
+  trap - EXIT
+
+  # Submit every cancellation before waiting so concurrently active jobs start
+  # shutting down as soon as possible.
   for job in "${JOB_IDS[@]}"; do
     scancel "${job}" 2>/dev/null || true
   done
+
+  # scancel can return before the job has left RUNNING/COMPLETING. Do not delete
+  # its checkpoint prefix while its processes may still be uploading objects.
+  for job in "${JOB_IDS[@]}"; do
+    waited=0
+    while squeue --jobs="${job}" --noheader >/dev/null 2>&1; do
+      if [ "${waited}" -ge "${CLEANUP_DEADLINE}" ]; then
+        echo "WARNING: job ${job} is still in Slurm after ${CLEANUP_DEADLINE}s; leaving verification objects intact." >&2
+        all_jobs_gone=false
+        break
+      fi
+      sleep 5
+      waited=$((waited + 5))
+    done
+  done
+
+  if [ "${all_jobs_gone}" != "true" ]; then
+    return
+  fi
+
   if [ -n "${PREFIX}" ]; then
     "${S5CMD[@]}" rm "s3://${NEBIUS_CHECKPOINT_BUCKET}/${PREFIX}/*" >/dev/null 2>&1 || true
     # The hard-kill phase interrupts an active upload, which can orphan an

--- a/slurm/object-storage-checkpointing/verify.sh
+++ b/slurm/object-storage-checkpointing/verify.sh
@@ -1,0 +1,220 @@
+#!/bin/bash
+# Automated pass/fail verification of the checkpointing installation.
+#
+# Run from this directory on a login node after bash setup.sh. It submits the
+# real example job (overridden to one GPU on each of two nodes, so cross-node
+# sharding is still exercised without needing a full allocation) and checks:
+#
+#   1. commit   - the job writes a checkpoint and commits the `latest` marker;
+#   2. kill     - after a hard SIGKILL (no graceful save possible), the marker
+#                 still points at a complete checkpoint. The kill is sent as
+#                 soon as the next upload is observed in flight; if none shows
+#                 up within one save cadence the job is killed anyway, so this
+#                 phase ATTEMPTS to interrupt an active upload but always
+#                 verifies hard-kill recovery;
+#   3. resume   - a new submission with the same prefix resumes from the
+#                 committed step and commits further progress;
+#   4. graceful - on SIGUSR1 the ranks commit the current step and exit.
+#
+# Deliberately NOT verified here: automatic Slurm requeue, real instance
+# preemption, and node recovery. Those depend on scheduler events and operator
+# action; the README's interruption section describes how to exercise them.
+#
+# Everything it writes lives under a unique verify-* prefix, which is deleted
+# at the end. Exits 0 only if all checks pass. Typical duration is ~5-10
+# minutes once the two nodes are allocated; queue time is extra.
+set -euo pipefail
+
+CHECKPOINTING_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+cd "${CHECKPOINTING_DIR}"
+export PATH="${CHECKPOINTING_DIR}/bin:${PATH}"
+
+# Generous per-phase deadlines; queue time counts against the first one.
+START_DEADLINE="${VERIFY_START_DEADLINE:-1800}"   # submit -> job running
+COMMIT_DEADLINE="${VERIFY_COMMIT_DEADLINE:-300}"  # running -> first commit
+RESUME_DEADLINE="${VERIFY_RESUME_DEADLINE:-300}"  # resume -> next commit
+
+set -a
+# shellcheck disable=SC1091 # rendered by the platform checkpointing setup
+source /etc/nebius-checkpoints.env
+set +a
+
+S5CMD=(s5cmd --endpoint-url "${NEBIUS_OBJECT_STORAGE_ENDPOINT}")
+
+fail() {
+  echo "FAIL: $*" >&2
+  exit 1
+}
+
+pass() {
+  echo "PASS: $*"
+}
+
+JOB_IDS=()
+PREFIX=""
+cleanup() {
+  for job in "${JOB_IDS[@]}"; do
+    scancel "${job}" 2>/dev/null || true
+  done
+  if [ -n "${PREFIX}" ]; then
+    "${S5CMD[@]}" rm "s3://${NEBIUS_CHECKPOINT_BUCKET}/${PREFIX}/*" >/dev/null 2>&1 || true
+    # The hard-kill phase interrupts an active upload, which can orphan an
+    # incomplete multipart upload that object listing does not show. Abort any
+    # under the verification prefix with the setup-created boto3 environment.
+    "${CHECKPOINTING_DIR}/.env/bin/python" - "${PREFIX}" <<'PYEOF' >/dev/null 2>&1 || true
+import os
+import sys
+
+import boto3
+from botocore.config import Config
+
+client = boto3.client(
+    "s3",
+    endpoint_url=os.environ["NEBIUS_OBJECT_STORAGE_ENDPOINT"],
+    region_name=os.environ["NEBIUS_OBJECT_STORAGE_REGION"],
+    config=Config(
+        s3={"addressing_style": "path"},
+        retries={"max_attempts": 5, "mode": "standard"},
+    ),
+)
+bucket = os.environ["NEBIUS_CHECKPOINT_BUCKET"]
+for page in client.get_paginator("list_multipart_uploads").paginate(
+    Bucket=bucket, Prefix=sys.argv[1] + "/"
+):
+    for upload in page.get("Uploads") or []:
+        client.abort_multipart_upload(
+            Bucket=bucket, Key=upload["Key"], UploadId=upload["UploadId"]
+        )
+PYEOF
+  fi
+}
+trap cleanup EXIT
+
+read_marker() {
+  # Prints the committed step, or nothing if the marker does not exist yet.
+  "${S5CMD[@]}" cat "s3://${NEBIUS_CHECKPOINT_BUCKET}/${PREFIX}/latest" 2>/dev/null | tr -d '[:space:]'
+}
+
+step_is_complete() {
+  # A committed step must contain the DCP metadata object written last. The
+  # trainer zero-pads step directories to eight digits (step-00000123/).
+  "${S5CMD[@]}" ls \
+    "s3://${NEBIUS_CHECKPOINT_BUCKET}/${PREFIX}/step-$(printf '%08d' "$1")/.metadata" \
+    >/dev/null 2>&1
+}
+
+newest_step_dir() {
+  # Prints the highest step number that has any objects, committed or not.
+  "${S5CMD[@]}" ls "s3://${NEBIUS_CHECKPOINT_BUCKET}/${PREFIX}/step-*" 2>/dev/null \
+    | grep -o 'step-[0-9]*' | sed 's/step-0*//;s/^$/0/' | sort -n | tail -n 1
+}
+
+job_state() {
+  squeue --noheader --format=%T --job "$1" 2>/dev/null | head -n 1
+}
+
+submit() {
+  # One GPU on each of two nodes: still cross-node and sharded, but does not
+  # need the full allocation the demo header requests.
+  TRAIN_ARGS="--prefix ${PREFIX} --save-every-seconds 20 --keep-last 2" \
+    sbatch --parsable --job-name=checkpointing-verify \
+    --gpus-per-node=1 --ntasks-per-node=1 checkpoint_train.sh
+}
+
+wait_running() { # jobid
+  local waited=0
+  while [ "$(job_state "$1")" != "RUNNING" ]; do
+    [ -n "$(job_state "$1")" ] || fail "job $1 left the queue before running (see outputs/checkpointing-verify-$1.out)"
+    [ "${waited}" -lt "${START_DEADLINE}" ] || fail "job $1 not running after ${START_DEADLINE}s (state: $(job_state "$1"))"
+    sleep 10; waited=$((waited + 10))
+  done
+}
+
+wait_gone() { # jobid deadline what
+  local waited=0
+  while [ -n "$(job_state "$1")" ]; do
+    [ "${waited}" -lt "$2" ] || fail "job $1 still in the queue $2s after $3"
+    sleep 5; waited=$((waited + 5))
+  done
+}
+
+wait_commit() { # min_exclusive_step deadline
+  local waited=0 marker
+  while true; do
+    marker="$(read_marker || true)"
+    if [ -n "${marker}" ] && [ "${marker}" -gt "$1" ] 2>/dev/null; then
+      echo "${marker}"
+      return
+    fi
+    [ "${waited}" -lt "$2" ] || fail "no checkpoint committed beyond step $1 within $2s"
+    sleep 5; waited=$((waited + 5))
+  done
+}
+
+PREFIX="verify-$(date +%Y%m%d-%H%M%S)-$$"
+echo "Verification prefix: s3://${NEBIUS_CHECKPOINT_BUCKET}/${PREFIX}/"
+
+echo "[1/4] Submitting the example job and waiting for the first committed checkpoint..."
+job1="$(submit)"
+JOB_IDS+=("${job1}")
+echo "  submitted job ${job1}"
+wait_running "${job1}"
+echo "  job ${job1} is running"
+committed="$(wait_commit -1 "${COMMIT_DEADLINE}")"
+step_is_complete "${committed}" || fail "marker names step ${committed} but its .metadata object is missing"
+pass "commit - job ${job1} committed checkpoint step ${committed}"
+
+echo "[2/4] Hard-killing the job (SIGKILL, no graceful save) and checking the marker..."
+# Kill the moment objects of a NEWER step appear: the next upload is then in
+# flight, so the SIGKILL lands mid-upload. If no new upload starts within the
+# save cadence, kill anyway - the invariant must hold at any moment.
+caught_in_flight=false
+waited=0
+while [ "${waited}" -lt 45 ]; do
+  newest="$(newest_step_dir || true)"
+  if [ -n "${newest}" ] && [ "${newest}" -gt "${committed}" ] 2>/dev/null; then
+    echo "  upload of step ${newest} is in flight"
+    caught_in_flight=true
+    break
+  fi
+  sleep 2; waited=$((waited + 2))
+done
+[ "${caught_in_flight}" = "true" ] \
+  || echo "  no new upload observed within 45s; killing anyway (hard-kill recovery is still verified)"
+scancel --signal=KILL "${job1}"
+wait_gone "${job1}" 120 "SIGKILL"
+marker_after_kill="$(read_marker)" \
+  || fail "marker missing or unreadable after SIGKILL"
+[ -n "${marker_after_kill}" ] || fail "marker is empty after SIGKILL"
+[ "${marker_after_kill}" -ge "${committed}" ] 2>/dev/null \
+  || fail "marker moved backwards after SIGKILL (${committed} -> ${marker_after_kill})"
+step_is_complete "${marker_after_kill}" \
+  || fail "marker names step ${marker_after_kill} but the checkpoint is incomplete after SIGKILL"
+pass "kill - marker still points at complete checkpoint step ${marker_after_kill}"
+
+echo "[3/4] Resubmitting with the same prefix and waiting for resume + new commit..."
+job2="$(submit)"
+JOB_IDS+=("${job2}")
+echo "  submitted job ${job2}"
+wait_running "${job2}"
+echo "  job ${job2} is running"
+resumed="$(wait_commit "${marker_after_kill}" "${RESUME_DEADLINE}")"
+log2="outputs/checkpointing-verify-${job2}.out"
+grep -q "resuming from checkpoint step ${marker_after_kill}" "${log2}" \
+  || fail "job ${job2} did not log resuming from step ${marker_after_kill} (see ${log2})"
+pass "resume - job ${job2} resumed from step ${marker_after_kill} and committed step ${resumed}"
+
+echo "[4/4] Sending SIGUSR1 (graceful stop) and waiting for the final checkpoint..."
+scancel --signal=USR1 "${job2}"
+wait_gone "${job2}" 180 "SIGUSR1"
+grep -q "exiting after signal at step" "${log2}" \
+  || fail "job ${job2} did not log a final checkpoint after SIGUSR1 (see ${log2})"
+final_marker="$(read_marker)" || fail "marker unreadable after graceful stop"
+[ "${final_marker}" -ge "${resumed}" ] 2>/dev/null \
+  || fail "marker moved backwards after graceful stop (${resumed} -> ${final_marker})"
+step_is_complete "${final_marker}" \
+  || fail "final checkpoint step ${final_marker} is incomplete"
+pass "graceful - job ${job2} checkpointed step ${final_marker} on SIGUSR1 and exited"
+
+echo
+echo "All checks passed. Cleaning up the ${PREFIX} prefix."

--- a/slurm/object-storage-checkpointing/verify.sh
+++ b/slurm/object-storage-checkpointing/verify.sh
@@ -34,9 +34,14 @@ START_DEADLINE="${VERIFY_START_DEADLINE:-1800}"   # submit -> job running
 COMMIT_DEADLINE="${VERIFY_COMMIT_DEADLINE:-300}"  # running -> first commit
 RESUME_DEADLINE="${VERIFY_RESUME_DEADLINE:-300}"  # resume -> next commit
 
+ENV_FILE='/etc/nebius-checkpoints.env'
+if [ ! -r "${ENV_FILE}" ]; then
+  echo "ERROR: ${ENV_FILE} is missing or unreadable; see the README's platform-operators section." >&2
+  exit 1
+fi
 set -a
-# shellcheck disable=SC1091 # rendered by the platform checkpointing setup
-source /etc/nebius-checkpoints.env
+# shellcheck disable=SC1090 # rendered at an installation-specific path
+source "${ENV_FILE}"
 set +a
 
 S5CMD=(s5cmd --endpoint-url "${NEBIUS_OBJECT_STORAGE_ENDPOINT}")

--- a/slurm/object-storage-checkpointing/verify.sh
+++ b/slurm/object-storage-checkpointing/verify.sh
@@ -73,6 +73,8 @@ client = boto3.client(
     endpoint_url=os.environ["NEBIUS_OBJECT_STORAGE_ENDPOINT"],
     region_name=os.environ["NEBIUS_OBJECT_STORAGE_REGION"],
     config=Config(
+        connect_timeout=10,
+        read_timeout=60,
         s3={"addressing_style": "path"},
         retries={"max_attempts": 5, "mode": "standard"},
     ),
@@ -207,7 +209,7 @@ pass "resume - job ${job2} resumed from step ${marker_after_kill} and committed 
 echo "[4/4] Sending SIGUSR1 (graceful stop) and waiting for the final checkpoint..."
 scancel --signal=USR1 "${job2}"
 wait_gone "${job2}" 180 "SIGUSR1"
-grep -q "exiting after signal at step" "${log2}" \
+grep -q "exiting after SIGUSR1 at step" "${log2}" \
   || fail "job ${job2} did not log a final checkpoint after SIGUSR1 (see ${log2})"
 final_marker="$(read_marker)" || fail "marker unreadable after graceful stop"
 [ "${final_marker}" -ge "${resumed}" ] 2>/dev/null \


### PR DESCRIPTION
## Summary

- add an end-to-end FSDP2 distributed-checkpoint example that writes shards directly to Nebius Object Storage
- demonstrate asynchronous saves, an atomic latest marker, automatic resume, checkpoint retention, and signal-aware final checkpoints
- add setup and four-phase verification scripts covering commit, hard-kill recovery, resume, and graceful shutdown
- document Soperator prerequisites, endpoint compatibility behavior, operations, troubleshooting, and disaster recovery
- link the new recipe from the cookbook index

## Validation

Validated end-to-end on a real Nebius Soperator 4.1.4 H100 cluster using two nodes and one GPU per node for the verification workload:

- Object Storage create/read/delete probe passed
- initial checkpoint committed at step 64
- SIGKILL during a newer upload left a complete committed checkpoint at step 144
- resubmitted job resumed from step 144 and committed step 207
- SIGUSR1 produced a synchronous final checkpoint at step 216
- verification prefix was removed and the test infrastructure was fully destroyed

Local checks:

- Ruff lint and format check
- Bandit security scan
- ShellCheck and Bash syntax checks
- Python compilation
- targeted malformed-marker and rendezvous-port behavior checks
- git diff whitespace validation

## Review follow-ups included

- derive AWS_ENDPOINT_URL from the authoritative Nebius endpoint before constructing the DCP client
- fail immediately for malformed checkpoint markers while retaining retries for transient Object Storage errors
- select a currently free rendezvous port while preserving explicit MASTER_PORT overrides
- use explicit standard retries for multipart-upload cleanup
- clarify post-kill marker errors and correct the documented checkpoint-size log line